### PR TITLE
[#10][fix] kapt-ktlint 의존성 설정

### DIFF
--- a/emo-diary/build.gradle.kts
+++ b/emo-diary/build.gradle.kts
@@ -82,3 +82,7 @@ sourceSets {
         }
     }
 }
+
+tasks.named("runKtlintCheckOverMainSourceSet") {
+    dependsOn("kaptKotlin")
+}


### PR DESCRIPTION
안녕하세요. 박재욱입니다.

gradle 빌드 시 kapt-ktlint의 의존성 문제가 발생해 해당 설정을 추가하면 해결되는 것을 확인하였습니다.

확인 부탁드립니다. 