### PR TITLE
[#8][feature]FcmToken용 API 추가

### DIFF
--- a/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/constant/FcmConstants.kt
+++ b/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/constant/FcmConstants.kt
@@ -1,0 +1,6 @@
+package com.fiveguysburger.emodiary.core.constant
+
+object FcmConstants {
+    const val FCM_TOKEN_KEY_PREFIX = "fcm:token:"
+    const val FCM_TOKEN_EXPIRY_DAYS = 14L // 2주
+}

--- a/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/controller/FcmTokenController.kt
+++ b/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/controller/FcmTokenController.kt
@@ -1,0 +1,59 @@
+package com.fiveguysburger.emodiary.core.controller
+
+import com.fiveguysburger.emodiary.core.dto.ApiResponse
+import com.fiveguysburger.emodiary.core.dto.request.FcmTokenRequest
+import com.fiveguysburger.emodiary.core.service.FcmTokenService
+import io.swagger.v3.oas.annotations.tags.Tag
+import org.springframework.web.bind.annotation.DeleteMapping
+import org.springframework.web.bind.annotation.GetMapping
+import org.springframework.web.bind.annotation.PathVariable
+import org.springframework.web.bind.annotation.PostMapping
+import org.springframework.web.bind.annotation.RequestBody
+import org.springframework.web.bind.annotation.RequestMapping
+import org.springframework.web.bind.annotation.RestController
+
+@RestController
+@RequestMapping("/api/v1/fcm")
+@Tag(name = "FCM 토큰", description = "FCM 토큰 관리 API")
+class FcmTokenController(
+    private val fcmTokenService: FcmTokenService,
+) {
+    @PostMapping("/token")
+    fun saveFcmToken(
+        @RequestBody request: FcmTokenRequest,
+    ): ApiResponse<Unit> {
+        fcmTokenService.saveFcmToken(request)
+        val savedToken = fcmTokenService.getFcmToken(request.userId)
+        return if (savedToken != null) {
+            ApiResponse.success(message = "FCM 토큰이 성공적으로 저장되었습니다.")
+        } else {
+            ApiResponse.error(message = "FCM 토큰 저장에 실패했습니다.")
+        }
+    }
+
+    @DeleteMapping("/token/{userId}")
+    fun deleteFcmToken(
+        @PathVariable userId: Int,
+    ): ApiResponse<Unit> {
+        val tokenBeforeDelete = fcmTokenService.getFcmToken(userId)
+        fcmTokenService.deleteFcmToken(userId)
+        val tokenAfterDelete = fcmTokenService.getFcmToken(userId)
+        return if (tokenBeforeDelete != null && tokenAfterDelete == null) {
+            ApiResponse.success(message = "FCM 토큰이 성공적으로 삭제되었습니다.")
+        } else {
+            ApiResponse.error(message = "FCM 토큰 삭제에 실패했습니다.")
+        }
+    }
+
+    @GetMapping("/token/{userId}")
+    fun getFcmToken(
+        @PathVariable userId: Int,
+    ): ApiResponse<String?> {
+        val token = fcmTokenService.getFcmToken(userId)
+        return if (token != null) {
+            ApiResponse.success(data = token, message = "FCM 토큰이 존재합니다.")
+        } else {
+            ApiResponse.success(data = null, message = "FCM 토큰이 존재하지 않습니다.")
+        }
+    }
+}

--- a/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/controller/NotificationTemplateController.kt
+++ b/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/controller/NotificationTemplateController.kt
@@ -2,8 +2,8 @@
 
 package com.fiveguysburger.emodiary.core.controller
 
-import com.fiveguysburger.emodiary.core.dto.NotificationTemplateRequestDto
-import com.fiveguysburger.emodiary.core.dto.NotificationTemplateResponseDto
+import com.fiveguysburger.emodiary.core.dto.request.NotificationTemplateRequestDto
+import com.fiveguysburger.emodiary.core.dto.response.NotificationTemplateResponseDto
 import com.fiveguysburger.emodiary.core.entity.NotificationTemplate
 import com.fiveguysburger.emodiary.core.service.NotificationTemplateService
 import io.swagger.v3.oas.annotations.Operation

--- a/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/dto/ApiResponse.kt
+++ b/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/dto/ApiResponse.kt
@@ -1,0 +1,16 @@
+package com.fiveguysburger.emodiary.core.dto
+
+data class ApiResponse<T>(
+    val success: Boolean,
+    val data: T? = null,
+    val message: String? = null,
+) {
+    companion object {
+        fun <T> success(
+            data: T? = null,
+            message: String? = null,
+        ): ApiResponse<T> = ApiResponse(success = true, data = data, message = message)
+
+        fun <T> error(message: String): ApiResponse<T> = ApiResponse(success = false, message = message)
+    }
+}

--- a/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/dto/request/FcmTokenRequest.kt
+++ b/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/dto/request/FcmTokenRequest.kt
@@ -1,0 +1,6 @@
+package com.fiveguysburger.emodiary.core.dto.request
+
+data class FcmTokenRequest(
+    val userId: Int,
+    val fcmToken: String,
+)

--- a/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/dto/request/NotificationTemplateRequestDto.kt
+++ b/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/dto/request/NotificationTemplateRequestDto.kt
@@ -1,4 +1,4 @@
-package com.fiveguysburger.emodiary.core.dto
+package com.fiveguysburger.emodiary.core.dto.request
 
 import io.swagger.v3.oas.annotations.media.Schema
 

--- a/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/dto/response/FcmTokenResponse.kt
+++ b/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/dto/response/FcmTokenResponse.kt
@@ -1,0 +1,7 @@
+package com.fiveguysburger.emodiary.core.dto.response
+
+data class FcmTokenResponse(
+    val userId: Int,
+    val fcmToken: String,
+    val expiresAt: String,
+)

--- a/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/dto/response/NotificationTemplateResponseDto.kt
+++ b/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/dto/response/NotificationTemplateResponseDto.kt
@@ -1,4 +1,4 @@
-package com.fiveguysburger.emodiary.core.dto
+package com.fiveguysburger.emodiary.core.dto.response
 
 import io.swagger.v3.oas.annotations.media.Schema
 import java.time.LocalDateTime

--- a/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/service/FcmTokenService.kt
+++ b/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/service/FcmTokenService.kt
@@ -1,0 +1,24 @@
+package com.fiveguysburger.emodiary.core.service
+
+import com.fiveguysburger.emodiary.core.dto.request.FcmTokenRequest
+
+interface FcmTokenService {
+    /**
+     * FCM 토큰을 저장합니다.
+     * @param request FCM 토큰 저장 요청
+     */
+    fun saveFcmToken(request: FcmTokenRequest)
+
+    /**
+     * 사용자의 FCM 토큰을 삭제합니다.
+     * @param userId 사용자 ID
+     */
+    fun deleteFcmToken(userId: Int)
+
+    /**
+     * 사용자의 FCM 토큰을 조회합니다.
+     * @param userId 사용자 ID
+     * @return FCM 토큰
+     */
+    fun getFcmToken(userId: Int): String?
+}

--- a/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/service/NotificationTemplateService.kt
+++ b/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/service/NotificationTemplateService.kt
@@ -1,7 +1,7 @@
 package com.fiveguysburger.emodiary.core.service
 
-import com.fiveguysburger.emodiary.core.dto.NotificationTemplateRequestDto
-import com.fiveguysburger.emodiary.core.dto.NotificationTemplateResponseDto
+import com.fiveguysburger.emodiary.core.dto.request.NotificationTemplateRequestDto
+import com.fiveguysburger.emodiary.core.dto.response.NotificationTemplateResponseDto
 import com.fiveguysburger.emodiary.core.entity.NotificationTemplate
 
 interface NotificationTemplateService {

--- a/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/service/impl/FcmTokenServiceImpl.kt
+++ b/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/service/impl/FcmTokenServiceImpl.kt
@@ -1,0 +1,28 @@
+package com.fiveguysburger.emodiary.core.service.impl
+
+import com.fiveguysburger.emodiary.core.constant.FcmConstants
+import com.fiveguysburger.emodiary.core.dto.request.FcmTokenRequest
+import com.fiveguysburger.emodiary.core.service.FcmTokenService
+import org.springframework.data.redis.core.RedisTemplate
+import org.springframework.stereotype.Service
+import java.time.Duration
+
+@Service
+class FcmTokenServiceImpl(
+    private val redisTemplate: RedisTemplate<String, String>,
+) : FcmTokenService {
+    override fun saveFcmToken(request: FcmTokenRequest) {
+        val key = FcmConstants.FCM_TOKEN_KEY_PREFIX + request.userId
+        redisTemplate.opsForValue().set(key, request.fcmToken, Duration.ofDays(FcmConstants.FCM_TOKEN_EXPIRY_DAYS))
+    }
+
+    override fun deleteFcmToken(userId: Int) {
+        val key = FcmConstants.FCM_TOKEN_KEY_PREFIX + userId
+        redisTemplate.delete(key)
+    }
+
+    override fun getFcmToken(userId: Int): String? {
+        val key = FcmConstants.FCM_TOKEN_KEY_PREFIX + userId
+        return redisTemplate.opsForValue().get(key)
+    }
+}

--- a/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/service/impl/NotificationTemplateServiceImpl.kt
+++ b/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/service/impl/NotificationTemplateServiceImpl.kt
@@ -1,7 +1,7 @@
 package com.fiveguysburger.emodiary.core.service.impl
 
-import com.fiveguysburger.emodiary.core.dto.NotificationTemplateRequestDto
-import com.fiveguysburger.emodiary.core.dto.NotificationTemplateResponseDto
+import com.fiveguysburger.emodiary.core.dto.request.NotificationTemplateRequestDto
+import com.fiveguysburger.emodiary.core.dto.response.NotificationTemplateResponseDto
 import com.fiveguysburger.emodiary.core.entity.NotificationTemplate
 import com.fiveguysburger.emodiary.core.repository.NotificationTemplateRepository
 import com.fiveguysburger.emodiary.core.service.NotificationTemplateService
@@ -25,7 +25,8 @@ class NotificationTemplateServiceImpl(
 
     override fun getTemplate(id: Long): NotificationTemplateResponseDto {
         val template =
-            notificationTemplateRepository.findById(id)
+            notificationTemplateRepository
+                .findById(id)
                 .orElseThrow { NoSuchElementException("템플릿을 찾을 수 없습니다: $id") }
         return template.toResponseDto()
     }
@@ -40,20 +41,23 @@ class NotificationTemplateServiceImpl(
         request: NotificationTemplateRequestDto,
     ): NotificationTemplateResponseDto {
         val existingTemplate =
-            notificationTemplateRepository.findById(id)
+            notificationTemplateRepository
+                .findById(id)
                 .orElseThrow { NoSuchElementException("템플릿을 찾을 수 없습니다: $id") }
 
-        return notificationTemplateRepository.save(
-            existingTemplate.copy(
-                title = request.title,
-                content = request.content,
-            ),
-        ).toResponseDto()
+        return notificationTemplateRepository
+            .save(
+                existingTemplate.copy(
+                    title = request.title,
+                    content = request.content,
+                ),
+            ).toResponseDto()
     }
 
     override fun deactivateTemplate(id: Long) {
         val template =
-            notificationTemplateRepository.findById(id)
+            notificationTemplateRepository
+                .findById(id)
                 .orElseThrow { NoSuchElementException("템플릿을 찾을 수 없습니다: $id") }
 
         notificationTemplateRepository.save(template.copy(isActive = false))


### PR DESCRIPTION
안녕하세요. 백정현입니다.
프론트 단에서 FCM TOKEN용 정보를 로그인 시점에 저장, 로그아웃 시점에 삭제 하도록 호출했으면 합니다.
다만 로그아웃을 강제로 안하면 2주가량 TTL을 두어 자동으로 삭제가 되니, 
로그아웃 버튼을 누르는 게 아니면 그대로 놔두어야 알림이 갈 수 있습니다. 참고 바랍니다.

**작업 내용**
1. FCM 상수 추가
2. FCM TOKEN용 API 추가 (토큰 정보는 Redis로 저장)
3. ApiResponse로 공통 Response 추가
4. NotificationTemplate쪽 Dto 위치 수정(변동내용은 없음)
5. Request Reponse 추가