### PR TITLE
[#8][Refactor]미사용 알림로그 제거 / Notification log id값 Auto generated 방식에서 uuid로 변경

### DIFF
--- a/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/controller/NotificationLogController.kt
+++ b/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/controller/NotificationLogController.kt
@@ -65,7 +65,7 @@ class NotificationLogController(
      */
     @DeleteMapping("/{id}")
     fun deleteNotificationLog(
-        @PathVariable id: Long,
+        @PathVariable id: String,
     ): ResponseEntity<Unit> {
         notificationLogService.deleteNotificationLog(id)
         return ResponseEntity.noContent().build()

--- a/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/dto/NotificationLogResponseDto.kt
+++ b/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/dto/NotificationLogResponseDto.kt
@@ -5,7 +5,7 @@ import com.fiveguysburger.emodiary.core.enums.NotificationStatus
 import com.fiveguysburger.emodiary.core.enums.NotificationType
 
 data class NotificationLogResponseDto(
-    val id: Long,
+    val id: String,
     val userId: Int,
     val sentAt: String,
     val templateId: Int,

--- a/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/entity/NotificationLog.kt
+++ b/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/entity/NotificationLog.kt
@@ -8,13 +8,14 @@ import jakarta.persistence.*
 import org.hibernate.proxy.HibernateProxy
 import java.time.LocalDateTime
 import java.util.Objects
+import java.util.UUID
 
 @Entity
 @Table(name = "notification_logs")
 data class NotificationLog(
     @Id
-    @GeneratedValue(strategy = GenerationType.IDENTITY)
-    val id: Long = 0,
+    @Column(name = "id", length = 36)
+    val id: String = UUID.randomUUID().toString(),
     @Column(name = "user_id")
     val userId: Int,
     @Column(name = "sent_at")

--- a/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/repository/NotificationLogRepository.kt
+++ b/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/repository/NotificationLogRepository.kt
@@ -6,5 +6,5 @@ import org.springframework.stereotype.Repository
 
 @Repository
 interface NotificationLogRepository :
-    JpaRepository<NotificationLog, Long>,
+    JpaRepository<NotificationLog, String>,
     NotificationLogRepositoryCustom

--- a/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/repository/NotificationLogRepositoryCustom.kt
+++ b/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/repository/NotificationLogRepositoryCustom.kt
@@ -27,7 +27,7 @@ interface NotificationLogRepositoryCustom {
      * @param errorMessage 에러 메시지 (선택)
      */
     fun updateNotificationStatus(
-        id: Long,
+        id: String,
         status: NotificationStatus,
         fcmMessageId: String?,
         errorMessage: String?,
@@ -46,7 +46,10 @@ interface NotificationLogRepositoryCustom {
      * @param templateId 템플릿 ID
      * @return 해당 조건의 알림 로그 목록
      */
-    fun findByUserIdAndTemplateIdOrderByCreatedAtDesc(userId: Int, templateId: Int): List<NotificationLog>
+    fun findByUserIdAndTemplateIdOrderByCreatedAtDesc(
+        userId: Int,
+        templateId: Int,
+    ): List<NotificationLog>
 
     /**
      * 특정 일수 이상 지난 알림 로그를 삭제합니다.

--- a/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/repository/impl/NotificationLogRepositoryImpl.kt
+++ b/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/repository/impl/NotificationLogRepositoryImpl.kt
@@ -41,8 +41,7 @@ class NotificationLogRepositoryImpl(
                         .from(QNotificationLog.notificationLog)
                         .where(QNotificationLog.notificationLog.sentAt.after(cutoffDate.atStartOfDay())),
                 ),
-            )
-            .distinct()
+            ).distinct()
             .fetch()
 
     /**
@@ -54,7 +53,7 @@ class NotificationLogRepositoryImpl(
      */
     @Transactional
     override fun updateNotificationStatus(
-        id: Long,
+        id: String,
         status: NotificationStatus,
         fcmMessageId: String?,
         errorMessage: String?,
@@ -86,14 +85,16 @@ class NotificationLogRepositoryImpl(
      * @param templateId 템플릿 ID
      * @return 해당 조건의 알림 로그 목록
      */
-    override fun findByUserIdAndTemplateIdOrderByCreatedAtDesc(userId: Int, templateId: Int): List<NotificationLog> =
+    override fun findByUserIdAndTemplateIdOrderByCreatedAtDesc(
+        userId: Int,
+        templateId: Int,
+    ): List<NotificationLog> =
         queryFactory
             .selectFrom(QNotificationLog.notificationLog)
             .where(
                 QNotificationLog.notificationLog.userId.eq(userId),
                 QNotificationLog.notificationLog.templateId.eq(templateId),
-            )
-            .orderBy(QNotificationLog.notificationLog.createdAt.desc())
+            ).orderBy(QNotificationLog.notificationLog.createdAt.desc())
             .fetch()
 
     /**

--- a/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/service/NotificationLogService.kt
+++ b/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/service/NotificationLogService.kt
@@ -50,7 +50,7 @@ interface NotificationLogService {
      * @param errorMessage 에러 메시지 (선택)
      */
     fun updateNotificationStatus(
-        id: Long,
+        id: String,
         status: NotificationStatus,
         fcmMessageId: String? = null,
         errorMessage: String? = null,
@@ -74,5 +74,5 @@ interface NotificationLogService {
      * 특정 알림 로그를 삭제합니다.
      * @param id 삭제할 알림 로그 ID
      */
-    fun deleteNotificationLog(id: Long)
+    fun deleteNotificationLog(id: String)
 }

--- a/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/service/impl/FcmServiceImpl.kt
+++ b/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/service/impl/FcmServiceImpl.kt
@@ -31,15 +31,7 @@ class FcmServiceImpl(
                 notificationTemplateService.getTemplateByType(message.notificationType.value)
                     ?: throw FcmException("템플릿을 찾을 수 없습니다: ${message.notificationType}")
 
-            // 2. 알림 로그 생성 (PENDING 상태로 시작)
-            val notificationLog =
-                notificationLogService.createNotificationLog(
-                    userId = message.userId,
-                    templateId = template.id.toInt(),
-                    notificationType = message.notificationType,
-                )
-
-            // 3. RabbitMQ를 통해 메시지 전송
+            // 2. RabbitMQ를 통해 메시지 전송
             val notificationMessage =
                 NotificationMessageDto(
                     userId = message.userId,

--- a/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/service/impl/NotificationLogServiceImpl.kt
+++ b/emo-diary/src/main/kotlin/com/fiveguysburger/emodiary/core/service/impl/NotificationLogServiceImpl.kt
@@ -82,7 +82,7 @@ class NotificationLogServiceImpl(
      */
     @Transactional
     override fun updateNotificationStatus(
-        id: Long,
+        id: String,
         status: NotificationStatus,
         fcmMessageId: String?,
         errorMessage: String?,
@@ -120,7 +120,7 @@ class NotificationLogServiceImpl(
      * @param id 삭제할 알림 로그 ID
      */
     @Transactional
-    override fun deleteNotificationLog(id: Long) {
+    override fun deleteNotificationLog(id: String) {
         notificationLogRepository.deleteById(id)
     }
 }


### PR DESCRIPTION
안녕하세요 백정현입니다. 

**변경 사항**
1. 미사용 알림로그 제거
2. Notification log id값 Auto generated 방식에서 uuid로 변경

기존 FcmServiceImpl에서 sendMessage쪽에서 로그를 남기던 부분이
processNotification에서 처리가 되고 있습니다.
불필요한 중복으로 인해 미사용 부분을 제거 했습니다.

Notification Log의 ID값을 기존 Auto generate 방식으로 진행하고 있었으나, UUID값으로 변경해 진행하도록 했습니다.
DB에서도 상태값은 변경했으니, 반영 시 이슈 없을 예정입니다.